### PR TITLE
Upgrade to Rust 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "cancellation"
 version = "0.1.0"
+edition = "2018"
 authors = ["Daniel Grunwald <daniel@danielgrunwald.de>"]
 description = "A C#-like CancellationToken for Rust"
 readme = "README.md"


### PR DESCRIPTION
First of all - thanks for this project! 🙂

This PR just addresses some deprecation warnings (`try!`, `dyn Trait`, `ATOMIC_USIZE_INIT` etc.) and explicitly sets the `2018` edition in the `Cargo.toml`.